### PR TITLE
A single alignment box is displayed for verses that do not have any Greek text

### DIFF
--- a/src/components/AlignmentCard/AlignmentCard.js
+++ b/src/components/AlignmentCard/AlignmentCard.js
@@ -100,7 +100,7 @@ class AlignmentCard extends Component {
      // if there is no top words show warning alert
      if (topWords.length === 1 && !topWords[0].word) {
       alignmentCardContent = (
-        <div style={{...styles.content, width: '280px', height: '100px', fontSize: '20px', padding: '5px' }}>
+        <div style={{ ...styles.content, width: '280px', height: '100px', fontSize: '20px', padding: '5px' }}>
           {noBibleTextWarning}
         </div>
       );

--- a/src/components/AlignmentCard/AlignmentCard.js
+++ b/src/components/AlignmentCard/AlignmentCard.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-
+// constants
+const noBibleTextWarning = `[WARNING: This Bible version does not include text for this reference.]`;
 /**
  * Generates the styles for the component
  * @param props
@@ -82,8 +83,9 @@ const makeStyles = (props) => {
 /**
  * Renders the alignment of primary and secondary words/phrases
  *
+ * @property {array} topWordCards
+ * @property {array} bottomWordsCards
  * @property {array} topWords
- * @property {array} bottomWords
  * @property {bool} hoverBottom - a bottom word is hover over this component
  * @property {bool} hoverTop - a top word is hovering over this component
  * @property {bool} acceptsTopWords - this component accepts dropped top words
@@ -91,23 +93,37 @@ const makeStyles = (props) => {
  */
 class AlignmentCard extends Component {
   render() {
-    const { bottomWords, topWords } = this.props;
+    const { bottomWordsCards, topWordCards, topWords } = this.props;
     const styles = makeStyles(this.props);
+    let alignmentCardContent = <div/>;
 
-    return (
-      <div style={styles.root}>
+     // if there is no top words show warning alert
+     if (topWords.length === 1 && !topWords[0].word) {
+      alignmentCardContent = (
+        <div style={{...styles.content, width: '280px', height: '100px', fontSize: '20px', padding: '5px' }}>
+          {noBibleTextWarning}
+        </div>
+      );
+    } else {
+      alignmentCardContent = (
         <div style={styles.content}>
           <div style={styles.top}>
             <div style={styles.topRow}>
-              {topWords}
+              {topWordCards}
             </div>
           </div>
           <div style={styles.bottom}>
             <div style={styles.bottomRow}>
-              {bottomWords}
+              {bottomWordsCards}
             </div>
           </div>
         </div>
+      );
+    }
+
+    return (
+      <div style={styles.root}>
+        {alignmentCardContent}
       </div>
     );
   }
@@ -115,7 +131,8 @@ class AlignmentCard extends Component {
 
 AlignmentCard.propTypes = {
   topWords: PropTypes.array,
-  bottomWords: PropTypes.array,
+  topWordCards: PropTypes.array,
+  bottomWordsCards: PropTypes.array,
   hoverBottom: PropTypes.bool,
   hoverTop: PropTypes.bool,
   acceptsTopWords: PropTypes.bool,

--- a/src/components/AlignmentCard/index.js
+++ b/src/components/AlignmentCard/index.js
@@ -71,7 +71,8 @@ class DroppableAlignmentCard extends Component {
                          hoverTop={hoverTop}
                          acceptsBottomWords={acceptsBottom}
                          acceptsTopWords={acceptsTop}
-                         topWords={topWordCards}/>
+                         topWordCards={topWordCards}
+                         topWords={topWords}/>
         </div>
       );
     }


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- A single alignment box is displayed for verses that do not have any Greek text

#### Please include detailed Test instructions for your pull request:
- Open a project with `wordAlignment tool` that has an empty verse. 
- Go to that empty verse and a warning should display (`[WARNING: This Bible version does not include text for this reference.]`)

- **Dependencies:**
   - https://github.com/translationCoreApps/ScripturePane/pull/117

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)
