### PR TITLE
Now removing USFM markers that were previously unsupported

### DIFF
--- a/src/Api.js
+++ b/src/Api.js
@@ -11,6 +11,7 @@ import {
 import path from 'path-extra';
 import Lexer from 'word-map/Lexer';
 import {tokenizeVerseObjects} from './utils/verseObjects';
+import {removeUsfmMarkers} from './utils/usfmHelpers';
 import {
   alignTargetToken,
   clearState,
@@ -65,7 +66,8 @@ export default class Api extends ToolApi {
     for (const verse of Object.keys(targetBible[chapter])) {
       const sourceTokens = tokenizeVerseObjects(
         sourceBible[chapter][verse].verseObjects);
-      const targetTokens = Lexer.tokenize(targetBible[chapter][verse]);
+      const targetVerseText = removeUsfmMarkers(targetBible[chapter][verse]);
+      const targetTokens = Lexer.tokenize(targetVerseText);
       resetVerse(chapter, verse, sourceTokens, targetTokens);
     }
   }
@@ -243,9 +245,9 @@ export default class Api extends ToolApi {
       return true;
     }
 
-    const sourceTokens = tokenizeVerseObjects(
-      sourceBible[chapter][verse].verseObjects);
-    const targetTokens = Lexer.tokenize(targetBible[chapter][verse]);
+    const sourceTokens = tokenizeVerseObjects(sourceBible[chapter][verse].verseObjects);
+    const targetVerseText = removeUsfmMarkers(targetBible[chapter][verse]);
+    const targetTokens = Lexer.tokenize(targetVerseText);
     const normalizedSource = sourceTokens.map(t => t.toString()).join(' ');
     const normalizedTarget = targetTokens.map(t => t.toString()).join(' ');
     const isValid = getIsVerseValid(store.getState(), chapter, verse,
@@ -303,7 +305,7 @@ export default class Api extends ToolApi {
     const {tc: {contextId, targetVerseText, sourceVerse}} = props;
     if (contextId) {
       const {reference: {chapter, verse}} = contextId;
-      const targetTokens = Lexer.tokenize(targetVerseText);
+      const targetTokens = Lexer.tokenize(removeUsfmMarkers(targetVerseText));
       const sourceTokens = tokenizeVerseObjects(sourceVerse.verseObjects);
       return {
         chapterIsLoaded: getIsChapterLoaded(state, chapter),

--- a/src/components/Container.js
+++ b/src/components/Container.js
@@ -30,6 +30,7 @@ import {
 import {connect} from 'react-redux';
 import {tokenizeVerseObjects} from '../utils/verseObjects';
 import {sortPanesSettings} from '../utils/panesSettingsHelper';
+import {removeUsfmMarkers} from '../utils/usfmHelpers';
 import Token from 'word-map/structures/Token';
 import MAPControls from './MAPControls';
 import {ScripturePane} from 'tc-ui-toolkit';
@@ -519,10 +520,11 @@ const mapDispatchToProps = ({
 
 const mapStateToProps = (state, props) => {
   const {tc, translate, toolApi} = props;
-  const {contextId, targetVerseText, sourceVerse} = tc;
+  let {contextId, targetVerseText, sourceVerse} = tc;
   const {reference: {chapter, verse}} = contextId;
+  console.log(sourceVerse);
   // TRICKY: the target verse contains punctuation we need to remove
-  const targetTokens = Lexer.tokenize(targetVerseText);
+  const targetTokens = Lexer.tokenize(removeUsfmMarkers(targetVerseText));
   const sourceTokens = tokenizeVerseObjects(sourceVerse.verseObjects);
   const normalizedSourceVerseText = sourceTokens.map(t => t.toString()).
     join(' ');

--- a/src/utils/usfmHelpers.js
+++ b/src/utils/usfmHelpers.js
@@ -1,0 +1,6 @@
+
+export const removeUsfmMarkers = (targetVerseText) => {
+  const regString = '\\\\\\w[0-9]*';
+  const regex = new RegExp(regString, 'g');
+  return targetVerseText.replace(regex, '');
+};

--- a/src/utils/usfmHelpers.js
+++ b/src/utils/usfmHelpers.js
@@ -1,6 +1,12 @@
+import usfmjs from 'usfm-js';
 
 export const removeUsfmMarkers = (targetVerseText) => {
+  const cleaned = usfmjs.removeMarker(
+    targetVerseText,
+    ['f', 'q(\\d)?', 's(\\d)?', 'p(\\d)?']
+  ); // remove these markers, 'f' is predefined
+
   const regString = '\\\\\\w[0-9]*';
   const regex = new RegExp(regString, 'g');
-  return targetVerseText.replace(regex, '');
+  return cleaned.replace(regex, '');
 };


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- Now removing USFM markers that were previously unsupported

#### Please include detailed Test instructions for your pull request:
- Load [jhn.usfm.zip](https://github.com/translationCoreApps/wordAlignment/files/2168503/jhn.usfm.zip) w/ wA tool
- Go to John 1:23
- No USFM markers should show up as words in the wA tool
- Aligning all the words from the word list should show the complete check mark in the menu.

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/translationcoreapps/wordalignment/49)
<!-- Reviewable:end -->
