### PR TITLE
updated alignment reset text

### DIFF
--- a/src/locale/English-en_US.json
+++ b/src/locale/English-en_US.json
@@ -5,7 +5,7 @@
   "morphology": "Morphology:",
   "strongs": "Strongs:",
   "lexicon": "Lexicon:",
-  "alignments_reset": "There have been changes to the current verse which interfere with your alignments.\nSome alignments for the current verse have been reset.",
+  "alignments_reset": "Changes have been detected in your project which have invalidated some of your alignments.\nThese verses display an icon of a broken chain next to the reference in the side menu.",
   "close": "Close",
   "select": "Select",
   "spelling": "Spelling",


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
related to https://github.com/unfoldingWord-dev/translationCore/issues/4319
- updated the text displayed when the alignments are reset after a verse edit.

#### Please include detailed Test instructions for your pull request:
- edit a verse with alignments and see the new dialog text.

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)
