### PR TITLE
MAP buttons are disabled when there no suggestions

### DIFF
--- a/src/components/Container.js
+++ b/src/components/Container.js
@@ -445,6 +445,7 @@ class Container extends Component {
 
   render() {
     const {
+      hasRenderedSuggestions,
       connectDropTarget,
       isOver,
       hasSourceText,
@@ -520,6 +521,7 @@ class Container extends Component {
             <MissingBibleError translate={translate}/>
           )}
           <MAPControls onAccept={this.handleAcceptSuggestions}
+                       hasSuggestions={hasRenderedSuggestions}
                        complete={isComplete}
                        onToggleComplete={this.handleToggleComplete}
                        showPopover={showPopover}
@@ -567,6 +569,7 @@ Container.propTypes = {
   acceptAlignmentSuggestions: PropTypes.func.isRequired,
 
   // state props
+  hasRenderedSuggestions: PropTypes.bool.isRequired,
   verseIsAligned: PropTypes.bool.isRequired,
   verseIsComplete: PropTypes.bool.isRequired,
   sourceTokens: PropTypes.arrayOf(PropTypes.instanceOf(Token)).isRequired,
@@ -621,6 +624,7 @@ const mapStateToProps = (state, props) => {
   const normalizedTargetVerseText = targetTokens.map(t => t.toString()).
     join(' ');
   return {
+    hasRenderedSuggestions: getVerseHasRenderedSuggestions(state, chapter, verse),
     verseIsComplete: toolApi.getIsVerseFinished(chapter, verse),
     verseIsAligned: getIsVerseAligned(state, chapter, verse),
     hasSourceText: normalizedSourceVerseText !== '',

--- a/src/components/MAPControls.js
+++ b/src/components/MAPControls.js
@@ -32,9 +32,9 @@ Tooltip.propTypes = {
   delayShow: PropTypes.number
 };
 Tooltip.defaultProps = {
-  location: "bottom",
-  type: "dark",
-  effect: "solid",
+  location: 'bottom',
+  type: 'dark',
+  effect: 'solid',
   delayHide: 100,
   delayShow: 1000
 };
@@ -148,28 +148,45 @@ class MAPControls extends React.Component {
   }
 
   render() {
-    const {onRefresh, onAccept, onReject, translate, complete, onToggleComplete} = this.props;
+    const {
+      onRefresh,
+      onAccept,
+      onReject,
+      translate,
+      complete,
+      onToggleComplete,
+      hasSuggestions
+    } = this.props;
+
     return (
       <MuiThemeProvider>
         <div style={styles.root}>
           <InfoIcon style={styles.icon}
                     onClick={this._handleOnInfoClick}/>
-          <Tooltip tooltip={translate('suggestions.refresh_suggestions', {word_map: translate('_.map')})}>
-            <SecondaryButton style={styles.button} onClick={onRefresh}>
+          <Tooltip tooltip={translate('suggestions.refresh_suggestions',
+            {word_map: translate('_.map')})}>
+            <SecondaryButton style={styles.button}
+                             onClick={onRefresh}>
               <RefreshIcon style={styles.buttonIcon}/>
               {translate('suggestions.refresh')}
             </SecondaryButton>
           </Tooltip>
 
-          <Tooltip tooltip={translate('suggestions.accept_suggestions', {word_map: translate('_.map')})}>
-            <SecondaryButton style={styles.button} onClick={onAccept}>
+          <Tooltip tooltip={translate('suggestions.accept_suggestions',
+            {word_map: translate('_.map')})}>
+            <SecondaryButton style={styles.button}
+                             onClick={onAccept}
+                             disabled={!hasSuggestions}>
               <CheckIcon style={styles.buttonIcon}/>
               {translate('suggestions.accept')}
             </SecondaryButton>
           </Tooltip>
 
-          <Tooltip tooltip={translate('suggestions.reject_suggestions', {word_map: translate('_.map')})}>
-            <SecondaryButton style={styles.button} onClick={onReject}>
+          <Tooltip tooltip={translate('suggestions.reject_suggestions',
+            {word_map: translate('_.map')})}>
+            <SecondaryButton style={styles.button}
+                             onClick={onReject}
+                             disabled={!hasSuggestions}>
               <CancelIcon style={styles.buttonIcon}/>
               {translate('suggestions.reject')}
             </SecondaryButton>
@@ -191,6 +208,7 @@ class MAPControls extends React.Component {
 }
 
 MAPControls.propTypes = {
+  hasSuggestions: PropTypes.bool,
   showPopover: PropTypes.func.isRequired,
   onRefresh: PropTypes.func.isRequired,
   onAccept: PropTypes.func.isRequired,
@@ -198,5 +216,8 @@ MAPControls.propTypes = {
   translate: PropTypes.func.isRequired,
   complete: PropTypes.bool.isRequired,
   onToggleComplete: PropTypes.func.isRequired
+};
+MAPControls.defaultProps = {
+  hasSuggestions: true
 };
 export default MAPControls;


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
related to https://github.com/unfoldingWord-dev/translationCore/issues/4706
- The reject and accept buttons are disabled when there no alignment suggestions.

#### Please include detailed Test instructions for your pull request:
- open a verse with suggestions and ensure the two buttons mentioned above are **enabled**
- remove the suggestions (any way you wish) and ensure the two buttons are **disabled**

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/translationcoreapps/wordalignment/59)
<!-- Reviewable:end -->
