### PR TITLE
fixed bug saving alignment data for the entire book

### DIFF
--- a/src/__tests__/api.js
+++ b/src/__tests__/api.js
@@ -65,6 +65,11 @@ describe('saving', () => {
     const api = new Api();
     api.props = {
       tc: {
+        targetBible: {
+          1: {
+            1: "hello"
+          }
+        },
         writeProjectData: jest.fn(() => Promise.resolve()),
         contextId: {reference: {bookId: 'tit', chapter: 1}}
       }


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
Re: @mannycolon 
- This fixes a bug in saving the alignment data.

The visual affect of this bug would be: re-opening a project with invalid alignments in another chapter would always show a dialog indicating some alignments were reset.

#### Please include detailed Test instructions for your pull request:
- 

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/translationcoreapps/wordalignment/62)
<!-- Reviewable:end -->
