### PR TITLE
Fixed bug that would cause to wrongly display broken links in the wA tool

### DIFF
--- a/src/Api.js
+++ b/src/Api.js
@@ -79,7 +79,6 @@ export default class Api extends ToolApi {
         sourceBible[chapter][verse].verseObjects);
       const targetVerseText = removeUsfmMarkers(targetBible[chapter][verse]);
       const targetTokens = Lexer.tokenize(targetVerseText);
-      console.log('targetTokens', targetTokens, 'targetVerseText', targetVerseText);
       resetVerse(chapter, verse, sourceTokens, targetTokens);
     }
   }

--- a/src/Api.js
+++ b/src/Api.js
@@ -228,7 +228,6 @@ export default class Api extends ToolApi {
       return true;
     }
     for (const verse of Object.keys(targetBible[chapter])) {
-      console.log(verse, removeUsfmMarkers(verse), removeUsfmMarkers(verse) === verse);
       const isValid = this._validateVerse(props, chapter, verse);
       if (!isValid) {
         chapterIsValid = isValid;

--- a/src/Api.js
+++ b/src/Api.js
@@ -79,6 +79,7 @@ export default class Api extends ToolApi {
         sourceBible[chapter][verse].verseObjects);
       const targetVerseText = removeUsfmMarkers(targetBible[chapter][verse]);
       const targetTokens = Lexer.tokenize(targetVerseText);
+      console.log('targetTokens', targetTokens, 'targetVerseText', targetVerseText);
       resetVerse(chapter, verse, sourceTokens, targetTokens);
     }
   }
@@ -227,6 +228,7 @@ export default class Api extends ToolApi {
       return true;
     }
     for (const verse of Object.keys(targetBible[chapter])) {
+      console.log(verse, removeUsfmMarkers(verse), removeUsfmMarkers(verse) === verse);
       const isValid = this._validateVerse(props, chapter, verse);
       if (!isValid) {
         chapterIsValid = isValid;

--- a/src/state/actions/index.js
+++ b/src/state/actions/index.js
@@ -2,6 +2,7 @@ import * as types from './actionTypes';
 import {migrateChapterAlignments} from '../../utils/migrations';
 import Lexer from 'word-map/Lexer';
 import {tokenizeVerseObjects} from '../../utils/verseObjects';
+import {removeUsfmMarkers} from '../../utils/usfmHelpers';
 import {getVerseAlignments, getRenderedVerseAlignments} from '../reducers';
 
 /**
@@ -48,7 +49,8 @@ export const indexChapterAlignments = (
     const targetChapterTokens = {};
     const sourceChapterTokens = {};
     for (const verse of Object.keys(targetChapter)) {
-      targetChapterTokens[verse] = Lexer.tokenize(targetChapter[verse]);
+      const targetVerseText = removeUsfmMarkers(targetChapter[verse]);
+      targetChapterTokens[verse] = Lexer.tokenize(targetVerseText);
     }
     for (const verse of Object.keys(sourceChapter)) {
       sourceChapterTokens[verse] = tokenizeVerseObjects(


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
-

#### Please include detailed Test instructions for your pull request:
- Open the following projects with wA tool and they should not display any broken links in the menu
- https://git.door43.org/ult-pre-alignment/en_tit
-  [en_tstf_tit_book.zip](https://github.com/unfoldingWord-dev/translationCore/files/2214722/en_tstf_tit_book.zip) 

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/translationcoreapps/wordalignment/64)
<!-- Reviewable:end -->
