### PR TITLE
Fixes displaying invalid alignment suggestions

### DIFF
--- a/src/state/reducers/alignments/__tests__/render_alignments.test.js
+++ b/src/state/reducers/alignments/__tests__/render_alignments.test.js
@@ -458,7 +458,7 @@ describe('render alignments', () => {
       // partial suggestions are not currently supported
     });
 
-    it('cannot use a target token twice in suggestion', () => {
+    it('cannot suggest a token previously used in an alignment', () => {
       // we try to trick the algorithm to use a token after it has already been used.
       const state = {
         sourceTokens: [{}, {}],
@@ -487,7 +487,36 @@ describe('render alignments', () => {
       ]);
     });
 
-    it('cannot use a target token twice in alignment', () => {
+    it('cannot suggest an additional token that has already been used in an alignment', () => {
+      // we try to trick the algorithm to use a token after it has already been used.
+      const state = {
+        sourceTokens: [{}, {}],
+        targetTokens: [{}, {}, {}],
+        alignments: [
+          {sourceNgram: [0], targetNgram: [0]},
+          {sourceNgram: [1], targetNgram: [2]}
+        ],
+        suggestions: [
+          {sourceNgram: [0], targetNgram: [1]},
+          {sourceNgram: [1], targetNgram: [2, 0]} // suggest adding 0
+        ]
+      };
+      const result = testRenderer(state);
+      expect(result).toEqual([
+        {
+          alignments: [0],
+          sourceNgram: [0],
+          targetNgram: [0]
+        },
+        {
+          alignments: [1],
+          sourceNgram: [1],
+          targetNgram: [2]
+        }
+      ]);
+    });
+
+    it('cannot suggest a token that will later be used in an alignment', () => {
       // we try to trick the algorithm to use a token after it has already been used.
       const state = {
         sourceTokens: [{}, {}],
@@ -507,6 +536,35 @@ describe('render alignments', () => {
           alignments: [0],
           sourceNgram: [0],
           targetNgram: []
+        },
+        {
+          alignments: [1],
+          sourceNgram: [1],
+          targetNgram: [0]
+        }
+      ]);
+    });
+
+    it('cannot suggest an additional token that will later be used in an alignment', () => {
+      // we try to trick the algorithm to use a token after it has already been used.
+      const state = {
+        sourceTokens: [{}, {}],
+        targetTokens: [{}, {}, {}],
+        alignments: [
+          {sourceNgram: [0], targetNgram: [2]},
+          {sourceNgram: [1], targetNgram: [0]}
+        ],
+        suggestions: [
+          {sourceNgram: [0], targetNgram: [0, 2]}, // suggest adding 0
+          {sourceNgram: [1], targetNgram: [1]}
+        ]
+      };
+      const result = testRenderer(state);
+      expect(result).toEqual([
+        {
+          alignments: [0],
+          sourceNgram: [0],
+          targetNgram: [2]
         },
         {
           alignments: [1],

--- a/src/state/reducers/alignments/render.js
+++ b/src/state/reducers/alignments/render.js
@@ -6,6 +6,7 @@ import _ from 'lodash';
  * @param {object[]} alignments - an array of alignments
  * @param {object[]} suggestions - an array of alignment suggestions
  * @param {number} numSourceTokens - the number of source tokens in the verse
+ * @return the alignments rendered with suggestions.
  */
 const render = (alignments, suggestions, numSourceTokens) => {
   // index things
@@ -83,7 +84,6 @@ const render = (alignments, suggestions, numSourceTokens) => {
     // determine suggestion validity
     let suggestionIsValid = false;
     let finishedReadingSuggestion = false;
-    // let suggestionIsEmpty = false;
     let sourceNgramsMatch = false;
     // TRICKY: we may not have suggestions for everything
     if (tIndex < suggestionSourceIndex.length) {
@@ -92,7 +92,9 @@ const render = (alignments, suggestions, numSourceTokens) => {
         if (targetPos in targetIndex) {
           const index = targetIndex[targetPos];
           targetUsedElsewhere = alignmentQueue.indexOf(index) === -1;
-          break;
+          if(targetUsedElsewhere) {
+            break;
+          }
         }
       }
 


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
Related to https://github.com/unfoldingWord-dev/translationCore/issues/4800
- This fixes a bug in the alignment renderer that was allowing target tokens to be used more than once under certain situations.

#### Please include detailed Test instructions for your pull request:
- See the instructions in https://github.com/unfoldingWord-dev/translationCore/issues/4800
- The token should no longer be suggested.

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/translationcoreapps/wordalignment/66)
<!-- Reviewable:end -->
