### PR TITLE
fixed crashing when source text is empty

### DIFF
--- a/src/Api.js
+++ b/src/Api.js
@@ -333,8 +333,14 @@ export default class Api extends ToolApi {
     const {tc: {contextId, targetVerseText, sourceVerse}} = props;
     if (contextId) {
       const {reference: {chapter, verse}} = contextId;
-      const targetTokens = Lexer.tokenize(removeUsfmMarkers(targetVerseText));
-      const sourceTokens = tokenizeVerseObjects(sourceVerse.verseObjects);
+      let targetTokens = [];
+      let sourceTokens = [];
+      if(targetVerseText) {
+        targetTokens = Lexer.tokenize(removeUsfmMarkers(targetVerseText));
+      }
+      if(sourceVerse) {
+        sourceTokens = tokenizeVerseObjects(sourceVerse.verseObjects);
+      }
       return {
         chapterIsLoaded: getIsChapterLoaded(state, chapter),
         targetTokens,

--- a/src/components/Container.js
+++ b/src/components/Container.js
@@ -627,8 +627,14 @@ const mapStateToProps = (state, props) => {
   const {tc: {contextId, targetVerseText, sourceVerse}, tool: {api}} = props;
   const {reference: {chapter, verse}} = contextId;
   // TRICKY: the target verse contains punctuation we need to remove
-  const targetTokens = Lexer.tokenize(removeUsfmMarkers(targetVerseText));
-  const sourceTokens = tokenizeVerseObjects(sourceVerse.verseObjects);
+  let targetTokens = [];
+  let sourceTokens = [];
+  if(targetVerseText) {
+    targetTokens = Lexer.tokenize(removeUsfmMarkers(targetVerseText));
+  }
+  if(sourceVerse) {
+    sourceTokens = tokenizeVerseObjects(sourceVerse.verseObjects);
+  }
   const normalizedSourceVerseText = sourceTokens.map(t => t.toString()).
     join(' ');
   const normalizedTargetVerseText = targetTokens.map(t => t.toString()).


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
Related to https://github.com/unfoldingWord-dev/translationCore/issues/4911
- This fixes a bug causing wA to crash when opening a verse without any source/target text.

#### Please include detailed Test instructions for your pull request:
- See issue for steps to test.

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/translationcoreapps/wordalignment/70)
<!-- Reviewable:end -->
