### PR TITLE
Bugfix 5041/Fix for Loading Projects with front matter

### DIFF
--- a/src/Api.js
+++ b/src/Api.js
@@ -70,16 +70,18 @@ export default class Api extends ToolApi {
     } = props;
 
     for (const verse of Object.keys(targetBible[chapter])) {
-      if (sourceBible[chapter][verse] === undefined) {
-        console.warn(
-          `Missing passage ${chapter}:${verse} in source text. Skipping alignment initialization.`);
-        continue;
+      if (!isNaN(verse)) { // only load valid numbers
+        if (sourceBible[chapter][verse] === undefined) {
+          console.warn(
+            `Missing passage ${chapter}:${verse} in source text. Skipping alignment initialization.`);
+          continue;
+        }
+        const sourceTokens = tokenizeVerseObjects(
+          sourceBible[chapter][verse].verseObjects);
+        const targetVerseText = removeUsfmMarkers(targetBible[chapter][verse]);
+        const targetTokens = Lexer.tokenize(targetVerseText);
+        resetVerse(chapter, verse, sourceTokens, targetTokens);
       }
-      const sourceTokens = tokenizeVerseObjects(
-        sourceBible[chapter][verse].verseObjects);
-      const targetVerseText = removeUsfmMarkers(targetBible[chapter][verse]);
-      const targetTokens = Lexer.tokenize(targetVerseText);
-      resetVerse(chapter, verse, sourceTokens, targetTokens);
     }
   }
 


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- when loading chapters, only numerical verses are loaded (i.e. front matter will be skipped)

#### Please include detailed Test instructions for your pull request:
- test with tCore release-v1.0.0 branch.
- see original issue https://github.com/unfoldingWord-dev/translationCore/issues/5041.  Should be able to open project in both WA and TW.

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/translationcoreapps/wordalignment/79)
<!-- Reviewable:end -->
