### PR TITLE
Fixed progress calculation

### DIFF
--- a/src/Api.js
+++ b/src/Api.js
@@ -583,7 +583,7 @@ export default class Api extends ToolApi {
 
         totalVerses ++;
         const isAligned = getIsVerseAligned(store.getState(), chapter, verse);
-        if(isAligned && this.getIsVerseFinished(chapter, verse)) {
+        if(isAligned || this.getIsVerseFinished(chapter, verse)) {
           completeVerses ++;
         }
       }

--- a/src/__tests__/api-progress.js
+++ b/src/__tests__/api-progress.js
@@ -3,10 +3,10 @@ import * as reducers from '../state/reducers';
 jest.mock('../state/reducers');
 
 describe('get tool progress', () => {
-  it('has no progress', () => {
+  it('is not aligned or toggled complete', () => {
     const props = {
       tool: {
-        toolDataPathExistsSync: () => true
+        toolDataPathExistsSync: () => false // the finished check looks for a file
       },
       tc: {
         targetBook: {
@@ -26,11 +26,61 @@ describe('get tool progress', () => {
     expect(api.getProgress()).toEqual(0);
   });
 
-  it('has some progress', () => {
+  it('is not aligned but is toggled', () => {
+    const props = {
+      tool: {
+        toolDataPathExistsSync: () => true
+      },
+      tc: {
+        targetBook: {
+          '1': {
+            '1': {}
+          }
+        }
+      }
+    };
+    const api = new Api();
+    api.props = props;
+    api.context = {
+      store: {
+        getState: jest.fn()
+      }
+    };
+    expect(api.getProgress()).toEqual(1);
+  });
+
+  it('some things are aligned but everything is toggled complete', () => {
     reducers.__setIsVerseAligned('1', '2', true);
     const props = {
       tool: {
         toolDataPathExistsSync: () => true
+      },
+      tc: {
+        targetBook: {
+          '1': {
+            '1': {},
+            '2': {},
+            '3': {},
+            '4': {}
+          }
+        }
+      }
+    };
+    const api = new Api();
+    api.props = props;
+    api.context = {
+      store: {
+        getState: jest.fn()
+      }
+    };
+    expect(api.getProgress()).toEqual(1);
+  });
+
+  it('some things are aligned and nothing is toggled complete', () => {
+    reducers.__setIsVerseAligned('1', '2', true);
+    const props = {
+      tool: {
+        toolDataPathExistsSync: () => false
       },
       tc: {
         targetBook: {


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
Related to https://github.com/unfoldingWord-dev/translationCore/issues/5692 and https://github.com/unfoldingWord-dev/translationCore/issues/5694 and https://github.com/unfoldingWord-dev/translationCore/issues/5698 and https://github.com/unfoldingWord-dev/translationCore/issues/5699 and https://github.com/unfoldingWord-dev/translationCore/issues/5339

- This updates the progress calculation to count fully aligned verses or verse that have been toggled complete.

> I believe this will close all of the above issues.

#### Please include detailed Test instructions for your pull request:
- align all the target tokens to all of the source tokens in a verse. (This will automatically toggle the verse as complete).
- check the progress on the tool card.
- untoggle the verse but keep it aligned. The progress should remain the same.
- toggle a different verse that is not aligned and you should see the progress increase.
- check that the progress shown on the home screen matches what's shown on the tool card
- import some aligned usfm. The progress bar should correctly show the progress instead of just 0.

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/translationcoreapps/wordalignment/142)
<!-- Reviewable:end -->
