### PR TITLE
mark fully alligned verses as complete durring validation

### DIFF
--- a/src/Api.js
+++ b/src/Api.js
@@ -275,6 +275,7 @@ export default class Api extends ToolApi {
     const targetTokens = Lexer.tokenize(targetVerseText);
     const normalizedSource = sourceTokens.map(t => t.toString()).join(' ');
     const normalizedTarget = targetTokens.map(t => t.toString()).join(' ');
+    const isAligned = getIsVerseAligned(store.getState(), chapter, verse);
     const isValid = getIsVerseAlignmentsValid(store.getState(), chapter, verse,
       normalizedSource, normalizedTarget);
     if (!isValid) {
@@ -286,6 +287,9 @@ export default class Api extends ToolApi {
       this.setVerseFinished(chapter, verse, false);
       // TRICKY: if there were no alignments we fix silently
       return !wasChanged;
+    } else if (isAligned && !this.getIsVerseFinished(chapter, verse)) {
+      // TRICKY: record aligned verses as finished
+      this.setVerseFinished(chapter, verse, true);
     }
     return true;
   }


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
Related to https://github.com/unfoldingWord-dev/translationCore/issues/5692
- Fixes fully aligned verses not showing as complete in wA

#### Please include detailed Test instructions for your pull request:
-

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/translationcoreapps/wordalignment/156)
<!-- Reviewable:end -->
