### PR TITLE
Bugfix 5789/Fix Primary Word height for Hebrew in Alignment Area

### DIFF
--- a/src/components/AlignmentCard/index.js
+++ b/src/components/AlignmentCard/index.js
@@ -105,6 +105,7 @@ class DroppableAlignmentCard extends Component {
       sourceNgram,
       alignmentIndex,
       sourceFontSize,
+      paddingTop,
       sourceDirection,
       targetDirection,
       isSuggestion,
@@ -122,7 +123,7 @@ class DroppableAlignmentCard extends Component {
     const topWordCards = sourceNgram.map((token, index) => (
       <PrimaryToken
         key={index}
-        style={{fontSize: sourceFontSize}}
+        style={{fontSize: sourceFontSize, "padding-top": paddingTop}}
         translate={translate}
         direction={sourceDirection}
         wordIndex={index}
@@ -169,6 +170,7 @@ DroppableAlignmentCard.propTypes = {
   translate: PropTypes.func.isRequired,
   placeholderPosition: PropTypes.string,
   sourceFontSize: PropTypes.string,
+  paddingTop: PropTypes.string,
   dragItemType: PropTypes.string,
   isOver: PropTypes.bool.isRequired,
   canDrop: PropTypes.bool.isRequired,
@@ -190,7 +192,8 @@ DroppableAlignmentCard.propTypes = {
 DroppableAlignmentCard.defaultProps = {
   sourceDirection: 'ltr',
   targetDirection: 'ltr',
-  sourceFontSize: '100%'
+  sourceFontSize: '100%',
+  paddingTop: '9px',
 };
 
 const dragHandler = {

--- a/src/components/AlignmentCard/index.js
+++ b/src/components/AlignmentCard/index.js
@@ -104,8 +104,7 @@ class DroppableAlignmentCard extends Component {
       targetNgram,
       sourceNgram,
       alignmentIndex,
-      sourceFontSize,
-      paddingTop,
+      sourceStyle,
       sourceDirection,
       targetDirection,
       isSuggestion,
@@ -123,7 +122,7 @@ class DroppableAlignmentCard extends Component {
     const topWordCards = sourceNgram.map((token, index) => (
       <PrimaryToken
         key={index}
-        style={{fontSize: sourceFontSize, "padding-top": paddingTop}}
+        style={sourceStyle}
         translate={translate}
         direction={sourceDirection}
         wordIndex={index}
@@ -169,8 +168,7 @@ DroppableAlignmentCard.propTypes = {
   onAcceptTokenSuggestion: PropTypes.func,
   translate: PropTypes.func.isRequired,
   placeholderPosition: PropTypes.string,
-  sourceFontSize: PropTypes.string,
-  paddingTop: PropTypes.string,
+  sourceStyle: PropTypes.object.isRequired,
   dragItemType: PropTypes.string,
   isOver: PropTypes.bool.isRequired,
   canDrop: PropTypes.bool.isRequired,
@@ -192,8 +190,7 @@ DroppableAlignmentCard.propTypes = {
 DroppableAlignmentCard.defaultProps = {
   sourceDirection: 'ltr',
   targetDirection: 'ltr',
-  sourceFontSize: '100%',
-  paddingTop: '9px',
+  sourceStyle: {fontSize: "100%"},
 };
 
 const dragHandler = {

--- a/src/components/AlignmentGrid.js
+++ b/src/components/AlignmentGrid.js
@@ -38,8 +38,7 @@ class AlignmentGrid extends Component {
       sourceDirection,
       targetDirection,
       onAcceptTokenSuggestion,
-      sourceFontSize,
-      paddingTop,
+      sourceStyle,
       alignments,
       contextId
     } = this.props;
@@ -72,8 +71,7 @@ class AlignmentGrid extends Component {
 
                 <AlignmentCard
                   translate={translate}
-                  sourceFontSize={sourceFontSize}
-                  paddingTop={paddingTop}
+                  sourceStyle={sourceStyle}
                   sourceDirection={sourceDirection}
                   targetDirection={targetDirection}
                   onCancelTokenSuggestion={onCancelSuggestion}
@@ -132,8 +130,7 @@ AlignmentGrid.propTypes = {
   onDropSourceToken: PropTypes.func.isRequired,
   onCancelSuggestion: PropTypes.func.isRequired,
   onAcceptTokenSuggestion: PropTypes.func.isRequired,
-  sourceFontSize: PropTypes.string,
-  paddingTop: PropTypes.string,
+  sourceStyle: PropTypes.object.isRequired,
   alignments: PropTypes.array.isRequired,
   contextId: PropTypes.object,
   translate: PropTypes.func.isRequired,
@@ -146,8 +143,7 @@ AlignmentGrid.propTypes = {
 AlignmentGrid.defaultProps = {
   sourceDirection: 'ltr',
   targetDirection: 'ltr',
-  sourceFontSize: '100%',
-  paddingTop: '9px',
+  sourceStyle: {fontSize: "100%"},
 };
 
 export default AlignmentGrid;

--- a/src/components/AlignmentGrid.js
+++ b/src/components/AlignmentGrid.js
@@ -39,6 +39,7 @@ class AlignmentGrid extends Component {
       targetDirection,
       onAcceptTokenSuggestion,
       sourceFontSize,
+      paddingTop,
       alignments,
       contextId
     } = this.props;
@@ -72,6 +73,7 @@ class AlignmentGrid extends Component {
                 <AlignmentCard
                   translate={translate}
                   sourceFontSize={sourceFontSize}
+                  paddingTop={paddingTop}
                   sourceDirection={sourceDirection}
                   targetDirection={targetDirection}
                   onCancelTokenSuggestion={onCancelSuggestion}
@@ -131,6 +133,7 @@ AlignmentGrid.propTypes = {
   onCancelSuggestion: PropTypes.func.isRequired,
   onAcceptTokenSuggestion: PropTypes.func.isRequired,
   sourceFontSize: PropTypes.string,
+  paddingTop: PropTypes.string,
   alignments: PropTypes.array.isRequired,
   contextId: PropTypes.object,
   translate: PropTypes.func.isRequired,
@@ -143,7 +146,8 @@ AlignmentGrid.propTypes = {
 AlignmentGrid.defaultProps = {
   sourceDirection: 'ltr',
   targetDirection: 'ltr',
-  sourceFontSize: '100%'
+  sourceFontSize: '100%',
+  paddingTop: '9px',
 };
 
 export default AlignmentGrid;

--- a/src/components/Container.js
+++ b/src/components/Container.js
@@ -536,8 +536,10 @@ class Container extends Component {
 
     // TRICKY: make hebrew text larger
     let sourceFontSize = "100%";
+    let paddingTop = "9px";
     if(sourceLanguage === "hbo") {
       sourceFontSize = "200%";
+      paddingTop = "2px";
     }
 
     return (
@@ -569,6 +571,7 @@ class Container extends Component {
           {hasSourceText ? (
             <AlignmentGrid
               sourceFontSize={sourceFontSize}
+              paddingTop={paddingTop}
               sourceDirection={sourceDirection}
               targetDirection={targetDirection}
               alignments={verseAlignments}

--- a/src/components/Container.js
+++ b/src/components/Container.js
@@ -535,11 +535,9 @@ class Container extends Component {
     const isComplete = this._getIsComplete();
 
     // TRICKY: make hebrew text larger
-    let sourceFontSize = "100%";
-    let paddingTop = "9px";
+    let sourceStyle = {fontSize: "100%"};
     if(sourceLanguage === "hbo") {
-      sourceFontSize = "200%";
-      paddingTop = "2px";
+      sourceStyle = {fontSize: "200%", "padding-top": "2px", "line-height": "100%"};
     }
 
     return (
@@ -570,8 +568,7 @@ class Container extends Component {
           </div>
           {hasSourceText ? (
             <AlignmentGrid
-              sourceFontSize={sourceFontSize}
-              paddingTop={paddingTop}
+              sourceStyle={sourceStyle}
               sourceDirection={sourceDirection}
               targetDirection={targetDirection}
               alignments={verseAlignments}


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- Fix Primary Word div height for Hebrew in Alignment Area so it matches size of drop area below
- Center Hebrew text in Primary Word div.

#### Please include detailed Test instructions for your pull request:
- test using https://github.com/unfoldingWord-dev/translationCore/pull/5841
- can use this OT project https://git.door43.org/lrsallee/en_ult_rut_book
- in WA make sure Scripture Pane for Hebrew and alignment area matches screenshots at bottom of https://github.com/unfoldingWord-dev/translationCore/issues/5789

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/translationcoreapps/wordalignment/164)
<!-- Reviewable:end -->
