### PR TITLE
Added Unaligned Words Filter

### DIFF
--- a/src/Api.js
+++ b/src/Api.js
@@ -537,6 +537,11 @@ export default class Api extends ToolApi {
     return toolDataPathExistsSync(dataPath);
   }
 
+  getisVerseUnaligned(chapter, verse) {
+    const {store} = this.context;
+    return !getIsVerseAligned(store.getState(), chapter, verse);
+  }
+
   /**
    * Returns the number of verses that have invalidated alignments
    * @returns {number}

--- a/src/__tests__/api.js
+++ b/src/__tests__/api.js
@@ -103,7 +103,7 @@ describe('saving', () => {
 
     it('saves successfully', () => {
       global.console = {error: jest.fn()};
-      reducers.__setLegacyChapterAlignments({ hello : "world"});
+      reducers.__setLegacyChapterAlignments({hello: "world"});
       const api = new Api();
       api.props = {
         tc: {
@@ -120,7 +120,7 @@ describe('saving', () => {
         }
       };
       const nextState = {
-        tool: {hello : 'world'}
+        tool: {hello: 'world'}
       };
       const prevState = {
         tool: {foo: 'bar'}
@@ -221,6 +221,53 @@ describe('context', () => {
   });
 });
 
+describe('verse unaligned', () => {
+  it('is unaligned', () => {
+    const api = new Api();
+    api.context = {
+      store: {
+        getState: jest.fn(() => ({
+          alignments: {
+            1: {
+              1: {
+                alignments: [
+                  {
+                    "sourceNgram": [
+                      0
+                    ],
+                    "targetNgram": [
+                      0,
+                      3
+                    ]
+                  },
+                  {
+                    "sourceNgram": [
+                      1
+                    ],
+                    "targetNgram": [
+                      1,
+                      4
+                    ]
+                  },
+                  {
+                    "sourceNgram": [
+                      2
+                    ],
+                    "targetNgram": [
+                      2
+                    ]
+                  },
+                ]
+              }
+            }
+          }
+        }))
+      }
+    };
+    expect(api.getisVerseUnaligned(1, 1)).toEqual(true);
+  });
+});
+
 describe('verse finished', () => {
   it('is not finished', () => {
     const api = new Api();
@@ -293,7 +340,7 @@ describe('validate', () => {
     jest.restoreAllMocks();
   });
 
-  it('repairs a book', async() => {
+  it('repairs a book', async () => {
     reducers.__setIsVerseValid(false);
     reducers.__setVerseAlignedTargetTokens(['some', 'data']);
     const alignmentCompleteFileExists = false;
@@ -340,7 +387,7 @@ describe('validate', () => {
     expect(props.tool.writeToolData).toBeCalledWith('invalid/1/1.json', expect.any(String));
   });
 
-  it('repairs a verse', async() => {
+  it('repairs a verse', async () => {
     reducers.__setIsVerseValid(false);
     reducers.__setVerseAlignedTargetTokens(['some', 'data']);
     const alignmentCompleteFileExists = false;
@@ -387,7 +434,7 @@ describe('validate', () => {
     expect(props.tool.writeToolData).toBeCalledWith('invalid/1/1.json', expect.any(String));
   });
 
-  it('repairs a verse without alignment changes', async() => {
+  it('repairs a verse without alignment changes', async () => {
     reducers.__setIsVerseValid(false);
     reducers.__setIsVerseAligned(1, 1, false);
     reducers.__setVerseAlignedTargetTokens(['some', 'data']);
@@ -436,7 +483,7 @@ describe('validate', () => {
     expect(props.tool.writeToolData).not.toBeCalled();
   });
 
-  it('repairs modified aligned verse without alignment changes and returns not valid', async() => {
+  it('repairs modified aligned verse without alignment changes and returns not valid', async () => {
     reducers.__setIsVerseValid(false);
     reducers.__setIsVerseAligned(1, 1, true);
     reducers.__setVerseAlignedTargetTokens(['some', 'data']);

--- a/src/containers/GroupMenuContainer.js
+++ b/src/containers/GroupMenuContainer.js
@@ -9,6 +9,7 @@ import BookmarkIcon from '@material-ui/icons/Bookmark';
 import BlockIcon from '@material-ui/icons/Block';
 import ModeCommentIcon from '@material-ui/icons/ModeComment';
 import EditIcon from '@material-ui/icons/Edit';
+import UnalignedIcon from '@material-ui/icons/RemoveCircle';
 
 class GroupMenuContainer extends React.Component {
 
@@ -40,7 +41,8 @@ class GroupMenuContainer extends React.Component {
       ...item,
       title: `${bookName} ${chapter}:${verse}`,
       completed: toolApi.getIsVerseFinished(chapter, verse), // TODO: I could read from state if I load these into the reducer at startup.
-      invalid: toolApi.getIsVerseInvalid(chapter, verse)
+      invalid: toolApi.getIsVerseInvalid(chapter, verse),
+      unaligned: toolApi.getisVerseUnaligned(chapter, verse)
     };
   };
 
@@ -88,6 +90,11 @@ class GroupMenuContainer extends React.Component {
         label: translate('menu.comments'),
         key: 'comments',
         icon: <ModeCommentIcon/>
+      },
+      {
+        label: translate('menu.unaligned'),
+        key: 'unaligned',
+        icon: <UnalignedIcon/>
       }
     ];
 

--- a/src/locale/English-en_US.json
+++ b/src/locale/English-en_US.json
@@ -187,7 +187,8 @@
     "incomplete": "Incomplete",
     "verse_edit": "Verse edit",
     "comments": "Comments",
-    "menu_title": "Menu"
+    "menu_title": "Menu",
+    "unaligned": "Unaligned Words"
   },
   "suggestions": {
     "refresh_suggestions": "Refresh ${word_map}-generated suggestions.",

--- a/src/locale/English-en_US.json
+++ b/src/locale/English-en_US.json
@@ -188,7 +188,7 @@
     "verse_edit": "Verse edit",
     "comments": "Comments",
     "menu_title": "Menu",
-    "unaligned": "Unaligned Words"
+    "unaligned": "Unaligned words"
   },
   "suggestions": {
     "refresh_suggestions": "Refresh ${word_map}-generated suggestions.",


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- If either a target word is unaligned or an original language word is unaligned, this filter will display it. 

#### Please include detailed Test instructions for your pull request:
- Just open any project and select wA tool, once a verse is completely aligned it should no longer show if the `Unaligned` filter is selected.

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/translationcoreapps/wordalignment/177)
<!-- Reviewable:end -->
