### PR TITLE
Feature 6148/

### DIFF
--- a/src/state/actions/__tests__/actions.test.js
+++ b/src/state/actions/__tests__/actions.test.js
@@ -15,7 +15,7 @@ const middlewares = [thunk];
 const mockStore = configureMockStore(middlewares);
 
 describe('thunk actions', () => {
-  const initialState = {
+  const initialStateMultiSingle = {
     tool: {
       alignments: {
         "1": {
@@ -90,7 +90,82 @@ describe('thunk actions', () => {
       }
     }
   };
-  
+  const initialStateMultiMulti = {
+    tool: {
+      alignments: {
+        "1": {
+          "1": {
+            alignments: [
+              {
+                "sourceNgram": [
+                  0,
+                  1,
+                  3
+                ],
+                "targetNgram": []
+              },
+              {
+                "sourceNgram": [
+                  2,
+                  4
+                ],
+                "targetNgram": []
+              }
+            ],
+            sourceTokens: [
+              {
+                "text": "Παῦλος",
+                "position": 0,
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G39720",
+                "lemma": "Παῦλος",
+                "morph": "Gr,N,,,,,NMS,"
+              },
+              {
+                "text": "δοῦλος",
+                "position": 1,
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G14010",
+                "lemma": "δοῦλος",
+                "morph": "Gr,N,,,,,NMS,"
+              },
+              {
+                "text": "Θεοῦ",
+                "position": 2,
+                "occurrence": 1,
+                "occurrences": 2,
+                "strong": "G23160",
+                "lemma": "θεός",
+                "morph": "Gr,N,,,,,GMS,"
+              },
+              {
+                "text": "ἀπόστολος",
+                "position": 3,
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G06520",
+                "lemma": "ἀπόστολος",
+                "morph": "Gr,N,,,,,NMS,"
+              },
+              {
+                "text": "δὲ",
+                "position": 4,
+                "occurrence": 1,
+                "occurrences": 1,
+                "strong": "G11610",
+                "lemma": "δέ",
+                "morph": "Gr,CC,,,,,,,,"
+              }
+            ],
+            targetTokens: []
+          }
+        }
+      }
+    }
+  };
+
   it('unmerges source token to merge with alignment on the right', () => {
     const expectedActions = [
       {
@@ -107,9 +182,11 @@ describe('thunk actions', () => {
         'type': ALIGN_RENDERED_SOURCE_TOKEN,
         'verse': 1
       }];
-    const state = _.cloneDeep(initialState);
+    const state = _.cloneDeep(initialStateMultiSingle);
+    const prevAlignmentIndex = 0;
+    addTargetWordToAlignment(state, prevAlignmentIndex);
     const store = mockStore(state);
-    const action = actions.moveSourceToken(1, 1, 1, 0,
+    const action = actions.moveSourceToken(1, 1, 1, prevAlignmentIndex,
       new Token({text: 'hello'}).toJSON() // TRICKY: simplifies test output
     );
     store.dispatch(action);
@@ -117,7 +194,53 @@ describe('thunk actions', () => {
     expect(results).toEqual(expectedActions);
   });
 
-  it('merges source token to the left', () => {
+  it('merges single source token to the left and keeps target words', () => {
+    const expectedActions = [
+      {
+        'chapter': 1,
+        'index': 1,
+        'token': {'index': 0, 'occurrence': 1, 'occurrences': 1},
+        'type': UNALIGN_RENDERED_SOURCE_TOKEN,
+        'verse': 1
+      },
+      {
+        'chapter': 1,
+        'index': 0, // NOTE: this remains nextIndex
+        'token': {'index': 0, 'occurrence': 1, 'occurrences': 1},
+        'type': ALIGN_RENDERED_SOURCE_TOKEN,
+        'verse': 1
+      },
+      {
+        "chapter": 1,
+        "index": 0,
+        "token": {
+          "charPos": 0,
+          "lemmaString": "",
+          "metadata": {},
+          "morphString": "",
+          "sentenceCharLen": 0,
+          "sentenceTokenLen": 0,
+          "strongNumber": "",
+          "text": "",
+          "tokenOccurrence": 1,
+          "tokenOccurrences": 1,
+          "tokenPos": 0
+        },
+        "type": "WA::ALIGN_RENDERED_TARGET_TOKEN",
+        "verse": 1
+      }];
+    const state = _.cloneDeep(initialStateMultiSingle);
+    const prevAlignmentIndex = 1;
+    addTargetWordToAlignment(state, prevAlignmentIndex);
+    const store = mockStore(state);
+    const action = actions.moveSourceToken(1, 1, 0, prevAlignmentIndex,
+      new Token({text: 'hello'}).toJSON() // TRICKY: simplifies test output
+    );
+    store.dispatch(action);
+    expect(store.getActions()).toEqual(expectedActions);
+  });
+
+  it('merges single source token to the left with empty target words', () => {
     const expectedActions = [
       {
         'chapter': 1,
@@ -133,7 +256,7 @@ describe('thunk actions', () => {
         'type': ALIGN_RENDERED_SOURCE_TOKEN,
         'verse': 1
       }];
-    const state = _.cloneDeep(initialState);
+    const state = _.cloneDeep(initialStateMultiSingle);
     const store = mockStore(state);
     const action = actions.moveSourceToken(1, 1, 0, 1,
       new Token({text: 'hello'}).toJSON() // TRICKY: simplifies test output
@@ -142,7 +265,7 @@ describe('thunk actions', () => {
     expect(store.getActions()).toEqual(expectedActions);
   });
 
-  it('unmerges source token to same position (insert)', () => {
+  it('unmerges source token to same position (inserts new alignment)', () => {
     const expectedActions = [
       {
         'chapter': 1,
@@ -157,15 +280,44 @@ describe('thunk actions', () => {
         'type': INSERT_RENDERED_ALIGNMENT,
         'verse': 1
       }];
-    const state = _.cloneDeep(initialState);
+    const state = _.cloneDeep(initialStateMultiSingle);
+    const prevAlignmentIndex = 1;
+    addTargetWordToAlignment(state, prevAlignmentIndex);
     const store = mockStore(state);
-    const action = actions.moveSourceToken(1, 1, 1, 1,
+    const action = actions.moveSourceToken(1, 1, prevAlignmentIndex, prevAlignmentIndex,
       new Token({text: 'hello'}).toJSON() // TRICKY: simplifies test output
     );
     store.dispatch(action);
     expect(store.getActions()).toEqual(expectedActions);
   });
 
+  it('moves token from one multi-Alignment to another multi-alignment and drops target words', () => {
+    const expectedActions = [
+      {
+        'chapter': 1,
+        'index': 1,
+        'token': {'index': 0, 'occurrence': 1, 'occurrences': 1},
+        'type': UNALIGN_RENDERED_SOURCE_TOKEN,
+        'verse': 1
+      },
+      {
+        'chapter': 1,
+        'index': 0, // NOTE: this remains nextIndex
+        'token': {'index': 0, 'occurrence': 1, 'occurrences': 1},
+        'type': ALIGN_RENDERED_SOURCE_TOKEN,
+        'verse': 1
+      }];
+    const state = _.cloneDeep(initialStateMultiMulti);
+    const prevAlignmentIndex = 1;
+    addTargetWordToAlignment(state, prevAlignmentIndex);
+    const store = mockStore(state);
+    const action = actions.moveSourceToken(1, 1, 0, prevAlignmentIndex,
+      new Token({text: 'hello'}).toJSON() // TRICKY: simplifies test output
+    );
+    store.dispatch(action);
+    expect(store.getActions()).toEqual(expectedActions);
+  });
+  
   it('sets alignment suggestions', () => {
     const sourceTokens = [new Token({text: 'hello'})];
     const targetTokens = [new Token({text: 'world'})];
@@ -192,3 +344,14 @@ describe('thunk actions', () => {
     expect(store.getActions()).toEqual(expectedActions);
   });
 });
+
+//
+// Helper functions
+//
+
+function addTargetWordToAlignment(state, index, wordText) {
+  const verse1 = state.tool.alignments["1"]["1"];
+  const previousAlignment = verse1.alignments[index];
+  previousAlignment.targetNgram.push(new Token({text: wordText}).toJSON());
+}
+

--- a/src/state/actions/index.js
+++ b/src/state/actions/index.js
@@ -161,11 +161,12 @@ export const moveSourceToken = (
     const initialAlignments = getVerseAlignments(getState(), chapter, verse);
     dispatch(unalignSourceToken(chapter, verse, prevAlignmentIndex, token));
 
-    if (prevAlignmentIndex === nextAlignmentIndex) {
+    if (prevAlignmentIndex === nextAlignmentIndex) { // doing unmerge operation
       dispatch(insertSourceToken(chapter, verse, token));
     } else {
       // if we are dragging from an alignment with multiple merged words
       const sourceMerged = (initialAlignments[prevAlignmentIndex] && initialAlignments[prevAlignmentIndex].sourceNgram && initialAlignments[prevAlignmentIndex].sourceNgram.length) > 1;
+      const previousTargetAlignments = initialAlignments[prevAlignmentIndex] && initialAlignments[prevAlignmentIndex].targetNgram;
       let index = nextAlignmentIndex;
       if (!sourceMerged) {
         // TRICKY: shift the next index since we removed an alignment (i.e. we merged a single word into a merged alignment)
@@ -173,6 +174,9 @@ export const moveSourceToken = (
           prevAlignmentIndex);
       }
       dispatch(alignSourceToken(chapter, verse, index, token));
+      if (!sourceMerged && (previousTargetAlignments.length > 0)) { // move over aligned target words if we moved a single primary word
+        previousTargetAlignments.forEach(tartgetToken => dispatch(alignTargetToken(chapter, verse, index, tartgetToken)));
+      }
     }
   };
 };


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- Fix to move target words when merging alignments if source alignment had single Primary word.

#### Please include detailed Test instructions for your pull request:
- test with latest develop
- open a project in WA.
- try all examples in https://github.com/unfoldingword-dev/translationcore/issues/6148 to make sure they work.

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/translationcoreapps/wordalignment/187)
<!-- Reviewable:end -->
