### PR TITLE
Fixes #5938 - verbiage change for suggestion buttons tooltips

### DIFF
--- a/src/components/MAPControls.js
+++ b/src/components/MAPControls.js
@@ -163,8 +163,7 @@ class MAPControls extends React.Component {
         <div style={styles.root}>
           <InfoIcon style={styles.icon}
                     onClick={this._handleOnInfoClick}/>
-          <Tooltip tooltip={translate('suggestions.refresh_suggestions',
-            {word_map: translate('_.map')})}>
+          <Tooltip tooltip={translate('suggestions.refresh_suggestions')}>
             <SecondaryButton style={styles.button}
                              onClick={onRefresh}>
               <RefreshIcon style={styles.buttonIcon}/>
@@ -172,8 +171,7 @@ class MAPControls extends React.Component {
             </SecondaryButton>
           </Tooltip>
 
-          <Tooltip tooltip={translate('suggestions.accept_suggestions',
-            {word_map: translate('_.map')})}>
+          <Tooltip tooltip={translate('suggestions.accept_suggestions')}>
             <SecondaryButton style={styles.button}
                              onClick={onAccept}
                              disabled={!hasSuggestions}>
@@ -182,8 +180,7 @@ class MAPControls extends React.Component {
             </SecondaryButton>
           </Tooltip>
 
-          <Tooltip tooltip={translate('suggestions.reject_suggestions',
-            {word_map: translate('_.map')})}>
+          <Tooltip tooltip={translate('suggestions.reject_suggestions')}>
             <SecondaryButton style={styles.button}
                              onClick={onReject}
                              disabled={!hasSuggestions}>

--- a/src/locale/English-en_US.json
+++ b/src/locale/English-en_US.json
@@ -194,9 +194,9 @@
     "unaligned": "Unaligned words"
   },
   "suggestions": {
-    "refresh_suggestions": "Refresh ${word_map}-generated suggestions.",
-    "accept_suggestions": "Accept all ${word_map}-generated suggestions.",
-    "reject_suggestions": "Reject all ${word_map}-generated suggestions.",
+    "refresh_suggestions": "Refresh suggestions.",
+    "accept_suggestions": "Accept all suggestions.",
+    "reject_suggestions": "Reject all suggestions.",
     "none": "No new suggestions",
     "refresh": "Refresh",
     "accept": "Accept",


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- Verbiage change for #5938

#### Please include detailed Test instructions for your pull request:
- Load a project and go to the WA tool
- Mouse over the suggestion buttons at the bottom. They should say "Refresh suggestions", "Accept all suggestions" and "Reject all suggestions" (no longer have "MAP-generated" in the string)

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/translationcoreapps/wordalignment/191)
<!-- Reviewable:end -->
