### PR TITLE
Fix Loading Verse Edits In Group Menu

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1249,7 +1249,8 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -1267,11 +1268,13 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -1284,15 +1287,18 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -1395,7 +1401,8 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -1405,6 +1412,7 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -1417,17 +1425,20 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -1444,6 +1455,7 @@
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -1516,7 +1528,8 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -1526,6 +1539,7 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -1601,7 +1615,8 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -1631,6 +1646,7 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -1648,6 +1664,7 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -1686,11 +1703,13 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.0.3",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             }
           }
         },
@@ -4882,7 +4901,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4903,12 +4923,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4923,17 +4945,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5050,7 +5075,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5062,6 +5088,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5076,6 +5103,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5083,12 +5111,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -5107,6 +5137,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5187,7 +5218,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5199,6 +5231,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5284,7 +5317,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5320,6 +5354,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5339,6 +5374,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5382,12 +5418,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -8757,7 +8795,8 @@
           "version": "0.3.2",
           "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
           "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "braces": {
           "version": "2.3.2",
@@ -9013,7 +9052,8 @@
           "version": "6.0.2",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
           "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "micromatch": {
           "version": "3.1.10",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1249,8 +1249,7 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -1268,13 +1267,11 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -1287,18 +1284,15 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -1401,8 +1395,7 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "ini": {
               "version": "1.3.5",
@@ -1412,7 +1405,6 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -1425,20 +1417,17 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -1455,7 +1444,6 @@
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -1528,8 +1516,7 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -1539,7 +1526,6 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -1615,8 +1601,7 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -1646,7 +1631,6 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -1664,7 +1648,6 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -1703,13 +1686,11 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "yallist": {
               "version": "3.0.3",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             }
           }
         },
@@ -4901,8 +4882,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4923,14 +4903,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4945,20 +4923,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5075,8 +5050,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5088,7 +5062,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5103,7 +5076,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5111,14 +5083,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -5137,7 +5107,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5218,8 +5187,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5231,7 +5199,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5317,8 +5284,7 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5354,7 +5320,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5374,7 +5339,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5418,14 +5382,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -8795,8 +8757,7 @@
           "version": "0.3.2",
           "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
           "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "braces": {
           "version": "2.3.2",
@@ -9052,8 +9013,7 @@
           "version": "6.0.2",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
           "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "micromatch": {
           "version": "3.1.10",

--- a/src/Api.js
+++ b/src/Api.js
@@ -564,6 +564,18 @@ export default class Api extends ToolApi {
     return toolDataPathExistsSync(dataPath);
   }
 
+  getisVerseEdited(chapter, verse) {
+    const {
+      tc: {
+        projectDataPathExistsSync,
+        contextId
+      }
+    } = this.props;
+    const {reference: {bookId}} = contextId;
+    const dataPath = path.join('checkData', 'verseEdits', bookId, chapter + '', verse + '');
+    return projectDataPathExistsSync(dataPath);
+  }
+
   getisVerseUnaligned(chapter, verse) {
     const {store} = this.context;
     return !getIsVerseAligned(store.getState(), chapter, verse);

--- a/src/Api.js
+++ b/src/Api.js
@@ -564,7 +564,7 @@ export default class Api extends ToolApi {
     return toolDataPathExistsSync(dataPath);
   }
 
-  getisVerseEdited(chapter, verse) {
+  getIsVerseEdited(chapter, verse) {
     const {
       tc: {
         projectDataPathExistsSync,

--- a/src/__tests__/api.js
+++ b/src/__tests__/api.js
@@ -730,6 +730,44 @@ describe('get number of invalid checks', () => {
   });
 });
 
+describe('API.getisVerseEdited', () => {
+  it('should return that a verse has verse edits', () => {
+    let expectedHasVerseEdits = true;
+    const props = {
+      tc: {
+        projectDataPathExistsSync: () => true,
+        contextId: {
+          reference: {
+            bookId: 'luk'
+          }
+        }
+      }
+    };
+    const api = new Api();
+    api.props = props;
+    const hasVerseEdits = api.getInvalidChecks();
+    expect(hasVerseEdits).toBe(expectedHasVerseEdits);
+  });
+
+  it('should return that a verse does not have verse edits', () => {
+    let expectedHasVerseEdits = false;
+    const props = {
+      tc: {
+        projectDataPathExistsSync: () => false,
+        contextId: {
+          reference: {
+            bookId: 'luk'
+          }
+        }
+      }
+    };
+    const api = new Api();
+    api.props = props;
+    const hasVerseEdits = api.getInvalidChecks();
+    expect(hasVerseEdits).toBe(expectedHasVerseEdits);
+  });
+});
+
 //
 // helper functions
 //

--- a/src/__tests__/api.js
+++ b/src/__tests__/api.js
@@ -740,12 +740,18 @@ describe('API.getisVerseEdited', () => {
           reference: {
             bookId: 'luk'
           }
+        },
+        targetBook: {
+          '1': {
+            '1': {},
+            '2': {}
+          }
         }
       }
     };
     const api = new Api();
     api.props = props;
-    const hasVerseEdits = api.getInvalidChecks();
+    const hasVerseEdits = api.getisVerseEdited();
     expect(hasVerseEdits).toBe(expectedHasVerseEdits);
   });
 
@@ -758,12 +764,18 @@ describe('API.getisVerseEdited', () => {
           reference: {
             bookId: 'luk'
           }
+        },
+        targetBook: {
+          '1': {
+            '1': {},
+            '2': {}
+          }
         }
       }
     };
     const api = new Api();
     api.props = props;
-    const hasVerseEdits = api.getInvalidChecks();
+    const hasVerseEdits = api.getisVerseEdited();
     expect(hasVerseEdits).toBe(expectedHasVerseEdits);
   });
 });

--- a/src/__tests__/api.js
+++ b/src/__tests__/api.js
@@ -730,7 +730,7 @@ describe('get number of invalid checks', () => {
   });
 });
 
-describe('API.getisVerseEdited', () => {
+describe('API.getIsVerseEdited', () => {
   it('should return that a verse has verse edits', () => {
     let expectedHasVerseEdits = true;
     const props = {
@@ -751,7 +751,7 @@ describe('API.getisVerseEdited', () => {
     };
     const api = new Api();
     api.props = props;
-    const hasVerseEdits = api.getisVerseEdited();
+    const hasVerseEdits = api.getIsVerseEdited();
     expect(hasVerseEdits).toBe(expectedHasVerseEdits);
   });
 
@@ -775,7 +775,7 @@ describe('API.getisVerseEdited', () => {
     };
     const api = new Api();
     api.props = props;
-    const hasVerseEdits = api.getisVerseEdited();
+    const hasVerseEdits = api.getIsVerseEdited();
     expect(hasVerseEdits).toBe(expectedHasVerseEdits);
   });
 });

--- a/src/containers/GroupMenuContainer.js
+++ b/src/containers/GroupMenuContainer.js
@@ -43,7 +43,7 @@ class GroupMenuContainer extends React.Component {
       completed: toolApi.getIsVerseFinished(chapter, verse), // TODO: I could read from state if I load these into the reducer at startup.
       invalid: toolApi.getIsVerseInvalid(chapter, verse),
       unaligned: toolApi.getisVerseUnaligned(chapter, verse),
-      verseEdits: toolApi.getisVerseEdited(chapter, verse),
+      verseEdits: toolApi.getisVerseEdited(chapter, verse)
     };
   };
 

--- a/src/containers/GroupMenuContainer.js
+++ b/src/containers/GroupMenuContainer.js
@@ -42,7 +42,8 @@ class GroupMenuContainer extends React.Component {
       title: `${bookName} ${chapter}:${verse}`,
       completed: toolApi.getIsVerseFinished(chapter, verse), // TODO: I could read from state if I load these into the reducer at startup.
       invalid: toolApi.getIsVerseInvalid(chapter, verse),
-      unaligned: toolApi.getisVerseUnaligned(chapter, verse)
+      unaligned: toolApi.getisVerseUnaligned(chapter, verse),
+      verseEdits: toolApi.getisVerseEdited(chapter, verse),
     };
   };
 

--- a/src/containers/GroupMenuContainer.js
+++ b/src/containers/GroupMenuContainer.js
@@ -43,7 +43,7 @@ class GroupMenuContainer extends React.Component {
       completed: toolApi.getIsVerseFinished(chapter, verse), // TODO: I could read from state if I load these into the reducer at startup.
       invalid: toolApi.getIsVerseInvalid(chapter, verse),
       unaligned: toolApi.getisVerseUnaligned(chapter, verse),
-      verseEdits: toolApi.getisVerseEdited(chapter, verse)
+      verseEdits: toolApi.getIsVerseEdited(chapter, verse)
     };
   };
 


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- PR fixes the word alignment tool not showing verse edits after external edits

#### Please include detailed Test instructions for your pull request:
- Download the following:
[project](https://github.com/unfoldingWord-dev/translationCore/files/3157968/en_test_1ti_book.zip)
[usfm](https://github.com/unfoldingWord-dev/translationCore/files/3157971/55-1TI-all.usfm.zip)
- Overwrite the project with the USFM file
- Open wA tool, ensure verses 1:3, 1:20 show as having a verse edit and being unaligned in group menu

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/translationcoreapps/wordalignment/194)
<!-- Reviewable:end -->
