### PR TITLE
QAFail #5930 - Deselect WordBank words on map button clicks

### DIFF
--- a/src/components/Container.js
+++ b/src/components/Container.js
@@ -219,7 +219,7 @@ class Container extends Component {
     }
   }
 
-  shouldComponentUpdate(nextProps, nextState, nextContext) {
+  shouldComponentUpdate(nextProps, nextState) {
     // When resetWordList goes from true to false, we don't need to render again
     return !(this.state.resetWordList && !nextState.resetWordList);
   }
@@ -513,7 +513,7 @@ class Container extends Component {
       tc: {contextId: {reference: {chapter, verse}}}
     } = this.props;
     clearAlignmentSuggestions(chapter, verse);
-    this.handleResetWordList();q
+    this.handleResetWordList();
   }
 
   handleRemoveSuggestion(alignmentIndex, token) {

--- a/src/components/Container.js
+++ b/src/components/Container.js
@@ -150,6 +150,7 @@ class Container extends Component {
     this.getLabeledTargetTokens = this.getLabeledTargetTokens.bind(this);
     this.handleSnackbarClose = this.handleSnackbarClose.bind(this);
     this.handleModalOpen = this.handleModalOpen.bind(this);
+    this.handleResetWordList = this.handleResetWordList.bind(this);
     this.state = {
       loading: false,
       validating: false,
@@ -157,7 +158,7 @@ class Container extends Component {
       writing: false,
       snackText: null,
       canAutoComplete: false,
-      modalOpen: false,
+      resetWordList: false
     };
   }
 
@@ -168,8 +169,15 @@ class Container extends Component {
   }
 
   handleModalOpen(isOpen) {
+    if (isOpen) {
+      this.handleResetWordList();
+    }
+  }
+
+  handleResetWordList() {
+    console.log("RESETTING WORD LIST - STATE");
     this.setState( {
-      modalOpen: isOpen
+      resetWordList: true
     });
   }
 
@@ -190,10 +198,13 @@ class Container extends Component {
   componentDidUpdate(prevProps) {
     const {
       verseIsAligned,
-      verseIsComplete,
+      verseIsComplete
     } = this.props;
 
-    const {canAutoComplete} = this.state;
+    const {
+      canAutoComplete,
+      resetWordList
+    } = this.state;
 
     if (!Container.contextDidChange(this.props, prevProps)) {
       // auto complete the verse
@@ -201,6 +212,16 @@ class Container extends Component {
         this.handleToggleComplete(null, true);
       }
     }
+    if (resetWordList) {
+      this.setState({
+        resetWordList: false
+      });
+    }
+  }
+
+  shouldComponentUpdate(nextProps, nextState, nextContext) {
+    // When resetWordList goes from true to false, we don't need to render again
+    return !(this.state.resetWordList && !nextState.resetWordList);
   }
 
   /**
@@ -453,6 +474,7 @@ class Container extends Component {
         });
       }
     });
+    this.handleResetWordList();
   }
 
   handleAcceptSuggestions() {
@@ -463,6 +485,7 @@ class Container extends Component {
     // accepting all suggestions can auto-complete the verse
     this.enableAutoComplete();
     acceptAlignmentSuggestions(chapter, verse);
+    this.handleResetWordList();
   }
 
   handleToggleComplete(e, isChecked) {
@@ -481,6 +504,7 @@ class Container extends Component {
       this.disableAutoComplete();
       this.forceUpdate();
     });
+    this.handleResetWordList();
   }
 
   handleRejectSuggestions() {
@@ -489,6 +513,7 @@ class Container extends Component {
       tc: {contextId: {reference: {chapter, verse}}}
     } = this.props;
     clearAlignmentSuggestions(chapter, verse);
+    this.handleResetWordList();q
   }
 
   handleRemoveSuggestion(alignmentIndex, token) {
@@ -620,7 +645,7 @@ class Container extends Component {
             words={words}
             onDropTargetToken={this.handleUnalignTargetToken}
             connectDropTarget={connectDropTarget}
-            modalOpen={this.state.modalOpen}
+            reset={this.state.resetWordList}
             isOver={isOver}/>
         </div>
         <div style={styles.alignmentAreaContainer}>

--- a/src/components/WordList/__tests__/__snapshots__/DroppableWordList.test.js.snap
+++ b/src/components/WordList/__tests__/__snapshots__/DroppableWordList.test.js.snap
@@ -103,6 +103,7 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
         modalOpen={false}
         moveBackToWordBank={[Function]}
         onDropTargetToken={[Function]}
+        reset={false}
         verse={1}
         words={
           Array [
@@ -802,6 +803,7 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
         modalOpen={false}
         moveBackToWordBank={[Function]}
         onDropTargetToken={[Function]}
+        reset={false}
         verse={1}
         wordList={
           Object {

--- a/src/components/WordList/index.js
+++ b/src/components/WordList/index.js
@@ -38,7 +38,7 @@ class DroppableWordList extends React.Component {
   }
 
   resetSelectedWordsState(nextProps) {
-    if (this.props.chapter !== nextProps.chapter || this.props.verse !== nextProps.verse || this.props.modalOpen) {
+    if (this.props.chapter !== nextProps.chapter || this.props.verse !== nextProps.verse || nextProps.reset) {
       this.clearWordSelections();
     }
   }
@@ -145,11 +145,12 @@ DroppableWordList.propTypes = {
   onDropTargetToken: PropTypes.func.isRequired,
   wordList: PropTypes.object,
   direction: PropTypes.oneOf(['ltr', 'rtl']),
-  modalOpen: PropTypes.bool.isRequired
+  reset: PropTypes.bool
 };
 
 DroppableWordList.defaultProps = {
-  direction: 'ltr'
+  direction: 'ltr',
+  reset: false
 };
 
 /**


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
QAFail fix for https://github.com/unfoldingWord-dev/translationCore/issues/5930

#### Please include detailed Test instructions for your pull request:
- Use this branch in tC_apps/wordAlignment with the latest develop version of tC
- Run tC, Load a project, go into WA
- Select word(s) in the word bank. Now clicking on the following should clear those selections: scripture pane expansion, add bible to scripture pane, refresh/accept/reject (when not disabled), Alignment complete on and off.

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/translationcoreapps/wordalignment/197)
<!-- Reviewable:end -->
