### PR TITLE
Bugfix 6424/Clear group menu reducer every time WA is launched

### DIFF
--- a/src/Api.js
+++ b/src/Api.js
@@ -50,6 +50,7 @@ export default class Api extends ToolApi {
     this._clearCachedAlignmentMemory = this._clearCachedAlignmentMemory.bind(this);
     this.refreshGroupMenuItems = this.refreshGroupMenuItems.bind(this);
     this.getGroupMenuItem = this.getGroupMenuItem.bind(this);
+    this.clearGroupMenuReducer = this.clearGroupMenuReducer.bind(this);
   }
 
   /**
@@ -384,16 +385,23 @@ export default class Api extends ToolApi {
   }
 
   /**
+   * resets cached data in group menu reducer
+   */
+  clearGroupMenuReducer() {
+    const {store} = this.context;
+    if (store && store.dispatch) {
+      store.dispatch({type: types.CLEAR_GROUP_MENU}); // make sure group menu reducer is clear each time we change projects
+    }
+  }
+
+  /**
    * Lifecycle method
    */
   toolWillConnect() {
     const {clearState} = this.props;
     this._clearCachedAlignmentMemory();
     clearState();
-    const {store} = this.context;
-    if (store && store.dispatch) {
-      store.dispatch({type: types.CLEAR_GROUP_MENU}); // make sure group menu reducer is clear each time we change projects
-    }
+    this.clearGroupMenuReducer();
     this._loadBookAlignments(this.props);
   }
 
@@ -494,6 +502,7 @@ export default class Api extends ToolApi {
       }
     } = this.props;
     if (isReady && Api._didToolContextChange(prevContext, nextContext)) {
+      this.clearGroupMenuReducer();
       setTimeout(() => {
         const isValid = this._validateBook(nextProps);
         if (!isValid) {

--- a/src/Api.js
+++ b/src/Api.js
@@ -50,7 +50,7 @@ export default class Api extends ToolApi {
     this._clearCachedAlignmentMemory = this._clearCachedAlignmentMemory.bind(this);
     this.refreshGroupMenuItems = this.refreshGroupMenuItems.bind(this);
     this.getGroupMenuItem = this.getGroupMenuItem.bind(this);
-    this.clearGroupMenuReducer = this.clearGroupMenuReducer.bind(this);
+    this._clearGroupMenuReducer = this._clearGroupMenuReducer.bind(this);
   }
 
   /**
@@ -387,7 +387,7 @@ export default class Api extends ToolApi {
   /**
    * resets cached data in group menu reducer
    */
-  clearGroupMenuReducer() {
+  _clearGroupMenuReducer() {
     const store = this.context && this.context.store;
     if (store && store.dispatch) {
       store.dispatch({type: types.CLEAR_GROUP_MENU}); // make sure group menu reducer is clear each time we change projects
@@ -401,7 +401,7 @@ export default class Api extends ToolApi {
     const {clearState} = this.props;
     this._clearCachedAlignmentMemory();
     clearState();
-    this.clearGroupMenuReducer();
+    this._clearGroupMenuReducer();
     this._loadBookAlignments(this.props);
   }
 
@@ -502,8 +502,8 @@ export default class Api extends ToolApi {
       }
     } = this.props;
     if (isReady && Api._didToolContextChange(prevContext, nextContext)) {
-      if (nextContext.tool === 'wordAlignment') { // if launching tool, make sure we clear previous menu entries
-        this.clearGroupMenuReducer();
+      if (nextContext.tool === 'wordAlignment') { // if we changed from other tool context, we are launching tool - make sure we clear previous group menu entries
+        this._clearGroupMenuReducer();
       }
       setTimeout(() => {
         const isValid = this._validateBook(nextProps);

--- a/src/Api.js
+++ b/src/Api.js
@@ -388,7 +388,7 @@ export default class Api extends ToolApi {
    * resets cached data in group menu reducer
    */
   clearGroupMenuReducer() {
-    const {store} = this.context;
+    const store = this.context && this.context.store;
     if (store && store.dispatch) {
       store.dispatch({type: types.CLEAR_GROUP_MENU}); // make sure group menu reducer is clear each time we change projects
     }
@@ -502,7 +502,9 @@ export default class Api extends ToolApi {
       }
     } = this.props;
     if (isReady && Api._didToolContextChange(prevContext, nextContext)) {
-      this.clearGroupMenuReducer();
+      if (nextContext.tool === 'wordAlignment') { // if launching tool, make sure we clear previous menu entries
+        this.clearGroupMenuReducer();
+      }
       setTimeout(() => {
         const isValid = this._validateBook(nextProps);
         if (!isValid) {


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- fixes problem that edits in a checking tool would not immediately update state in group menu in WA.
- fix to clear groupMenu reducer every time WA is launched

#### Please include detailed Test instructions for your pull request:
- test using build attached at bottom of https://github.com/unfoldingWord-dev/translationCore/pull/6468
- import this project from usfm [57-TIT.usfm.zip](https://github.com/unfoldingWord-dev/translationCore/files/3591552/57-TIT.usfm.zip)
- open WA tool
- then open TN tool and edit verse
- go back to WA and make sure edited verse shows both edited and invalidated on group menu

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/translationcoreapps/wordalignment/214)
<!-- Reviewable:end -->
